### PR TITLE
Add Monitored Directory

### DIFF
--- a/src/main/java/org/pwss/controller/NewDirectoryController.java
+++ b/src/main/java/org/pwss/controller/NewDirectoryController.java
@@ -3,6 +3,7 @@ package org.pwss.controller;
 import org.pwss.model.service.MonitoredDirectoryService;
 import org.pwss.navigation.NavigationEvents;
 import org.pwss.navigation.Screen;
+import org.pwss.utils.StringConstants;
 import org.pwss.view.screen.NewDirectoryScreen;
 
 import javax.swing.*;
@@ -30,7 +31,7 @@ public class NewDirectoryController extends BaseController<NewDirectoryScreen> {
 
     @Override
     void refreshView() {
-        getScreen().getPathLabel().setText(selectedPath != null ? selectedPath : "No folder selected");
+        getScreen().getPathLabel().setText(selectedPath != null ? selectedPath : StringConstants.NEW_DIR_NO_PATH_SELECTED);
         getScreen().getCreateButton().setEnabled(selectedPath != null && !selectedPath.isEmpty());
     }
 
@@ -59,10 +60,10 @@ public class NewDirectoryController extends BaseController<NewDirectoryScreen> {
         if (selectedPath != null && !selectedPath.isEmpty()) {
             try {
                 monitoredDirectoryService.createNewMonitoredDirectory(selectedPath, includeSubdirectories, makeActive);
-                JOptionPane.showMessageDialog(getScreen().getRootPanel(), "Directory added successfully!", "Success", JOptionPane.INFORMATION_MESSAGE);
+                JOptionPane.showMessageDialog(getScreen().getRootPanel(), StringConstants.NEW_DIR_SUCCESS_TEXT, StringConstants.GENERIC_SUCCESS, JOptionPane.INFORMATION_MESSAGE);
                 NavigationEvents.navigateTo(Screen.HOME, null);
             } catch (Exception e) {
-                JOptionPane.showMessageDialog(getScreen().getRootPanel(), "Failed to add directory: " + e.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(getScreen().getRootPanel(), StringConstants.NEW_DIR_ERROR_PREFIX + e.getMessage(), StringConstants.GENERIC_ERROR, JOptionPane.ERROR_MESSAGE);
             }
         }
     }

--- a/src/main/java/org/pwss/utils/StringConstants.java
+++ b/src/main/java/org/pwss/utils/StringConstants.java
@@ -7,6 +7,8 @@ public final class StringConstants {
     // General purpose strings
     public static final String GENERIC_YES = "Yes";
     public static final String GENERIC_NO = "No";
+    public static final String GENERIC_SUCCESS = "Success";
+    public static final String GENERIC_ERROR = "Error";
 
     // Scan related strings
     public static final String SCAN_FULL = "Full scan";
@@ -35,4 +37,9 @@ public final class StringConstants {
     public static final String MON_DIR_POPUP_RESET_BASELINE_ERROR_INVALID = "Invalid code. Baseline reset cancelled.";
     public static final String MON_DIR_POPUP_RESET_BASELINE_ERROR_PREFIX = "Error resetting baseline: ";
     public static final String MON_DIR_POPUP_EDIT_DIR = "Edit this directory";
+
+    // New directory screen related strings
+    public static final String NEW_DIR_SUCCESS_TEXT = "Directory added successfully!";
+    public static final String NEW_DIR_ERROR_PREFIX = "Failed to add directory: ";
+    public static final String NEW_DIR_NO_PATH_SELECTED = "No directory selected.";
 }

--- a/src/main/java/org/pwss/view/screen/HomeScreen.form
+++ b/src/main/java/org/pwss/view/screen/HomeScreen.form
@@ -123,7 +123,7 @@
                   <text value="Scan logs"/>
                 </properties>
               </component>
-              <grid id="7210a" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="7210a" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="7" column="0" row-span="3" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -137,14 +137,6 @@
                     </constraints>
                     <properties>
                       <text value="New directory"/>
-                    </properties>
-                  </component>
-                  <component id="7539b" class="javax.swing.JButton" binding="editDirectoryButton">
-                    <constraints>
-                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                    </constraints>
-                    <properties>
-                      <text value="Edit directory"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/org/pwss/view/screen/HomeScreen.java
+++ b/src/main/java/org/pwss/view/screen/HomeScreen.java
@@ -169,14 +169,11 @@ public class HomeScreen extends BaseScreen {
         liveFeedTitle.setText("Scan logs");
         scanTab.add(liveFeedTitle, new GridConstraints(0, 1, 1, 2, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JPanel panel1 = new JPanel();
-        panel1.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
+        panel1.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));
         scanTab.add(panel1, new GridConstraints(7, 0, 3, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         newDirectoryButton = new JButton();
         newDirectoryButton.setText("New directory");
         panel1.add(newDirectoryButton, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        editDirectoryButton = new JButton();
-        editDirectoryButton.setText("Edit directory");
-        panel1.add(editDirectoryButton, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         liveFeedDiffCount = new JLabel();
         liveFeedDiffCount.setText("");
         scanTab.add(liveFeedDiffCount, new GridConstraints(9, 2, 1, 2, GridConstraints.ANCHOR_EAST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));

--- a/src/main/java/org/pwss/view/screen/NewDirectoryScreen.form
+++ b/src/main/java/org/pwss/view/screen/NewDirectoryScreen.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.pwss.view.screen.NewDirectoryScreen">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="true" hgap="-1" vgap="-1">
     <margin top="10" left="10" bottom="10" right="10"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,26 +8,10 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="6b71c" class="javax.swing.JButton" binding="cancelButton" default-binding="true">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Cancel"/>
-        </properties>
-      </component>
-      <component id="5b6d4" class="javax.swing.JButton" binding="createButton" default-binding="true">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Create"/>
-        </properties>
-      </component>
       <grid id="285ad" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -53,6 +37,7 @@
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <selected value="true"/>
               <text value="Include subdirectories"/>
             </properties>
           </component>
@@ -61,7 +46,34 @@
               <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
+              <selected value="true"/>
               <text value="Make directory active"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="d2e1a" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="5b6d4" class="javax.swing.JButton" binding="createButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Create"/>
+            </properties>
+          </component>
+          <component id="6b71c" class="javax.swing.JButton" binding="cancelButton" default-binding="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Cancel"/>
             </properties>
           </component>
         </children>

--- a/src/main/java/org/pwss/view/screen/NewDirectoryScreen.java
+++ b/src/main/java/org/pwss/view/screen/NewDirectoryScreen.java
@@ -65,16 +65,10 @@ public class NewDirectoryScreen extends BaseScreen {
      */
     private void $$$setupUI$$$() {
         rootPanel = new JPanel();
-        rootPanel.setLayout(new GridLayoutManager(3, 1, new Insets(10, 10, 10, 10), -1, -1));
-        cancelButton = new JButton();
-        cancelButton.setText("Cancel");
-        rootPanel.add(cancelButton, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
-        createButton = new JButton();
-        createButton.setText("Create");
-        rootPanel.add(createButton, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        rootPanel.setLayout(new GridLayoutManager(2, 1, new Insets(10, 10, 10, 10), -1, -1, false, true));
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(3, 2, new Insets(0, 0, 0, 0), -1, -1));
-        rootPanel.add(panel1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        rootPanel.add(panel1, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         pathLabel = new JLabel();
         pathLabel.setText("Please pick a path");
         panel1.add(pathLabel, new GridConstraints(0, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
@@ -82,11 +76,22 @@ public class NewDirectoryScreen extends BaseScreen {
         selectPathButton.setText("Select path");
         panel1.add(selectPathButton, new GridConstraints(1, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         includeSubdirectoriesCheckBox = new JCheckBox();
+        includeSubdirectoriesCheckBox.setSelected(true);
         includeSubdirectoriesCheckBox.setText("Include subdirectories");
         panel1.add(includeSubdirectoriesCheckBox, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         makeDirectoryActiveCheckBox = new JCheckBox();
+        makeDirectoryActiveCheckBox.setSelected(true);
         makeDirectoryActiveCheckBox.setText("Make directory active");
         panel1.add(makeDirectoryActiveCheckBox, new GridConstraints(2, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        final JPanel panel2 = new JPanel();
+        panel2.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
+        rootPanel.add(panel2, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        createButton = new JButton();
+        createButton.setText("Create");
+        panel2.add(createButton, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        cancelButton = new JButton();
+        cancelButton.setText("Cancel");
+        panel2.add(cancelButton, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
     }
 
     /**


### PR DESCRIPTION
This pull request refactors the UI and logic for directory creation and improves consistency in user-facing messages. It updates the layout of the Home and New Directory screens, sets sensible defaults, and centralizes string constants for better maintainability.

**UI layout and usability improvements:**

* The Home screen layout is simplified by removing the `editDirectoryButton` and reducing the grid to a single column, making the interface cleaner and focusing on the "New directory" action. (`HomeScreen.form`, `HomeScreen.java`) [[1]](diffhunk://#diff-f08bd9cfef797f622ef0bc99be44bd34bcdf8dc0ebb9571d54dd9130e0e9b870L126-R126) [[2]](diffhunk://#diff-f08bd9cfef797f622ef0bc99be44bd34bcdf8dc0ebb9571d54dd9130e0e9b870L142-L149) [[3]](diffhunk://#diff-a3baf7b270c0012c239208c802a3be188eca99077ec478569f2da6116cc67315L172-L179)
* The New Directory screen layout is refactored to group "Create" and "Cancel" buttons together at the bottom, and the grid row count is reduced for a more compact design. (`NewDirectoryScreen.form`, `NewDirectoryScreen.java`) [[1]](diffhunk://#diff-7609717a5f565ff2142b9621cfa55aa4f8b6a5a21d13f623a4be92671a56cc2bL3-R14) [[2]](diffhunk://#diff-7609717a5f565ff2142b9621cfa55aa4f8b6a5a21d13f623a4be92671a56cc2bR49-R80) [[3]](diffhunk://#diff-3c23343a3c921e34aa553a4e93e2ed5f8ac87628a6ee3f1cc0e3b314082e274eL68-R94)
* The "Include subdirectories" and "Make directory active" checkboxes now default to selected, streamlining the directory creation process for typical use cases. (`NewDirectoryScreen.form`, `NewDirectoryScreen.java`) [[1]](diffhunk://#diff-7609717a5f565ff2142b9621cfa55aa4f8b6a5a21d13f623a4be92671a56cc2bR40) [[2]](diffhunk://#diff-7609717a5f565ff2142b9621cfa55aa4f8b6a5a21d13f623a4be92671a56cc2bR49-R80) [[3]](diffhunk://#diff-3c23343a3c921e34aa553a4e93e2ed5f8ac87628a6ee3f1cc0e3b314082e274eL68-R94)

**Consistency and maintainability:**

* All user-facing strings related to directory creation (success, error, no path selected) and generic dialog titles ("Success", "Error") are moved to the centralized `StringConstants` class, reducing duplication and making localization easier. (`StringConstants.java`, `NewDirectoryController.java`) [[1]](diffhunk://#diff-3829c99b15fae240e7f651aaadceba49c3c908e70a2802e5671b7a9b7db5ece1R10-R11) [[2]](diffhunk://#diff-3829c99b15fae240e7f651aaadceba49c3c908e70a2802e5671b7a9b7db5ece1R40-R44) [[3]](diffhunk://#diff-f4465b9d8226fa942c64e424aadcd343ebf0d9badb7d9039489446cbb6af8382R6) [[4]](diffhunk://#diff-f4465b9d8226fa942c64e424aadcd343ebf0d9badb7d9039489446cbb6af8382L33-R34) [[5]](diffhunk://#diff-f4465b9d8226fa942c64e424aadcd343ebf0d9badb7d9039489446cbb6af8382L62-R66)
* The logic for displaying messages in the New Directory workflow now uses these constants for both content and dialog titles, ensuring consistent terminology throughout the app. (`NewDirectoryController.java`) [[1]](diffhunk://#diff-f4465b9d8226fa942c64e424aadcd343ebf0d9badb7d9039489446cbb6af8382L33-R34) [[2]](diffhunk://#diff-f4465b9d8226fa942c64e424aadcd343ebf0d9badb7d9039489446cbb6af8382L62-R66)


## Since this already was in the app I used the ticket to verify everything working as intended and did some minor improvements and cleanup