### PR TITLE
Bump jar name in start.ps1 script to launch 0.4

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -6,8 +6,8 @@ if ($null -eq $portInUse) {
     Write-Host "Nothing is running on port 15400. Starting the process..."
     java -jar "..\File-Integrity-Scanner\File-Integrity-Scanner\target\File-Integrity-Scanner-1.3.1.jar" & 
     Write-Host "File-Integrity-Scanner started."
-    java -jar .\target\file_integrity_gui-0.3.1-jar-with-dependencies.jar
+    java -jar .\target\file_integrity_gui-0.4-jar-with-dependencies.jar
 } else {
     Write-Host "File-Integrity-Scanner is already running on port 15400."
-    java -jar .\target\file_integrity_gui-0.3.1-jar-with-dependencies.jar
+    java -jar .\target\file_integrity_gui-0.4-jar-with-dependencies.jar
 }


### PR DESCRIPTION
## ⚠️ This must be merged before https://github.com/pwssOrg/File-Integrity-GUI/pull/28 ⚠️ 

This pull request updates the version of the GUI application launched by the `start.ps1` script. The script now starts `file_integrity_gui` version 0.4 instead of version 0.3.1. This ensures that users will run the latest available GUI when starting or connecting to the File Integrity Scanner process.