### PR TITLE
Update tab icon for files tab

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.pwss</groupId>
     <artifactId>integrity_hash</artifactId>
     <packaging>jar</packaging>
-    <version>1.1</version>
+    <version>1.2</version>
     <description>A GUI application for file integrity checking</description>
     
     <!-- Licenses -->

--- a/src/main/java/org/pwss/view/screen/HomeScreen.form
+++ b/src/main/java/org/pwss/view/screen/HomeScreen.form
@@ -243,7 +243,7 @@
           <grid id="64f52" binding="filesTab" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="10" left="10" bottom="10" right="10"/>
             <constraints>
-              <tabbedpane title="🗄️ Files"/>
+              <tabbedpane title="📁 Files"/>
             </constraints>
             <properties/>
             <border type="none"/>

--- a/src/main/java/org/pwss/view/screen/HomeScreen.java
+++ b/src/main/java/org/pwss/view/screen/HomeScreen.java
@@ -634,7 +634,7 @@ public class HomeScreen extends BaseScreen {
         scanTab.add(clearFeedButton, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_EAST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         filesTab = new JPanel();
         filesTab.setLayout(new GridLayoutManager(2, 1, new Insets(10, 10, 10, 10), -1, -1));
-        tabbedPane.addTab("\uD83D\uDDC4\uFE0F Files", filesTab);
+        tabbedPane.addTab("\uD83D\uDCC1 Files", filesTab);
         final JSplitPane splitPane2 = new JSplitPane();
         filesTab.add(splitPane2, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, new Dimension(200, 200), null, 0, false));
         final JScrollPane scrollPane4 = new JScrollPane();


### PR DESCRIPTION
This pull request makes a minor update to the application version and improves consistency in the UI by changing the "Files" tab icon from a filing cabinet to a folder. The most important changes are:

Version update:

* Bumped the project version from `1.1` to `1.2` in `pom.xml` to reflect the new release.

UI consistency:

* Changed the "Files" tab icon from a filing cabinet (🗄️) to a folder (📁) in both the `HomeScreen.form` and `HomeScreen.java` files for a clearer and more familiar representation. [[1]](diffhunk://#diff-f08bd9cfef797f622ef0bc99be44bd34bcdf8dc0ebb9571d54dd9130e0e9b870L246-R246) [[2]](diffhunk://#diff-a3baf7b270c0012c239208c802a3be188eca99077ec478569f2da6116cc67315L637-R637)