### PR TITLE
Update start script

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -8,14 +8,14 @@ if (-not (Test-Path -Path "..\artifacts")) {
 
 if ($null -eq $portInUse) {
     Write-Host "Nothing is running on port 15400. Starting the process..."
-    java -jar "..\File-Integrity-Scanner\File-Integrity-Scanner\target\File-Integrity-Scanner-1.7.jar" &
+    java -jar "..\File-Integrity-Scanner\File-Integrity-Scanner\target\File-Integrity-Scanner-1.8.1.jar" &
     Write-Host "File-Integrity-Scanner started."
-    cp .\target\integrity_hash-1.1-jar-with-dependencies.jar ..\artifacts
-    java -jar ..\artifacts\integrity_hash-1.1-jar-with-dependencies.jar
+    cp .\target\integrity_hash-1.2-jar-with-dependencies.jar ..\artifacts
+    java -jar ..\artifacts\integrity_hash-1.2-jar-with-dependencies.jar
     exit
 } else {
     Write-Host "File-Integrity-Scanner is already running on port 15400."
-    cp .\target\integrity_hash-1.1-jar-with-dependencies.jar ..\artifacts
-    java -jar ..\artifacts\integrity_hash-1.1-jar-with-dependencies.jar
+    cp .\target\integrity_hash-1.2-jar-with-dependencies.jar ..\artifacts
+    java -jar ..\artifacts\integrity_hash-1.2-jar-with-dependencies.jar
     exit
 }


### PR DESCRIPTION
This pull request updates the versions of the JAR files used and copied in the `start.ps1` script to ensure the latest builds are run and distributed.

Version updates:

* Updated the `File-Integrity-Scanner` JAR file reference from version `1.7` to `1.8.1` when starting the process.
* Updated the `integrity_hash` JAR file references from version `1.1` to `1.2` when copying to the `artifacts` directory and executing the JAR.