### PR TITLE
Updated start.ps1 script

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -8,14 +8,14 @@ if (-not (Test-Path -Path "..\artifacts")) {
 
 if ($null -eq $portInUse) {
     Write-Host "Nothing is running on port 15400. Starting the process..."
-    java -jar "..\File-Integrity-Scanner\File-Integrity-Scanner\target\File-Integrity-Scanner-1.8.1.jar" &
+    java -jar "..\File-Integrity-Scanner\File-Integrity-Scanner\target\File-Integrity-Scanner-1.8.3.jar" &
     Write-Host "File-Integrity-Scanner started."
-    cp .\target\integrity_hash-1.2-jar-with-dependencies.jar ..\artifacts
-    java -jar ..\artifacts\integrity_hash-1.2-jar-with-dependencies.jar
+    cp .\target\integrity_hash-1.2.1-jar-with-dependencies.jar ..\artifacts
+    java -jar ..\artifacts\integrity_hash-1.2.1-jar-with-dependencies.jar
     exit
 } else {
     Write-Host "File-Integrity-Scanner is already running on port 15400."
-    cp .\target\integrity_hash-1.2-jar-with-dependencies.jar ..\artifacts
-    java -jar ..\artifacts\integrity_hash-1.2-jar-with-dependencies.jar
+    cp .\target\integrity_hash-1.2.1-jar-with-dependencies.jar ..\artifacts
+    java -jar ..\artifacts\integrity_hash-1.2.1-jar-with-dependencies.jar
     exit
 }


### PR DESCRIPTION
This pull request updates the versions of the JAR files used in the `start.ps1` script to ensure the latest builds are used for both the File Integrity Scanner and the integrity hash utility.

Version updates:

* Updated the File Integrity Scanner JAR reference from version `1.8.1` to `1.8.3` in the `java -jar` command.
* Updated the integrity hash JAR references from version `1.2` to `1.2.1` in both the `cp` and `java -jar` commands, ensuring the script always uses the latest version.