### PR TITLE
Bump various dependencies (Jackson core, logback & junit)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.pwss</groupId>
     <artifactId>integrity_hash</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <description>A GUI application for file integrity checking</description>
     
     <!-- Licenses -->
@@ -25,25 +25,17 @@
         </license>
     </licenses>
 
-    <!-- Cool developers B-) -->
+    <!-- Developers -->
     <developers>
         <developer>
             <name>Peter Westin</name>
-            <id>Peter</id>
-            <email>snow_900@outlook.com</email>
-            <roles>
-                <role>Coa supporter</role>
-            </roles>
-            <timezone>Central European Time</timezone>
+            <email>peter.westin@pwss.dev</email>
+            <timezone>Europe/Stockholm</timezone>
         </developer>
         <developer>
             <name>Stefan Smudja</name>
-            <id>Stefan</id>
-            <email>stefan-201@hotmail.com</email>
-            <roles>
-                <role>Developer King</role>
-            </roles>
-            <timezone>Central European Time</timezone>
+            <email>stefan.smudja@pwss.dev</email>
+            <timezone>Europe/Stockholm</timezone>
         </developer>
     </developers>
 
@@ -58,25 +50,25 @@
     <!-- Project dependencies -->
     <dependencies>
         <!-- Jackson Databind dependency for JSON processing -->
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.21.0 -->
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.21.3 -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.0</version>
+            <version>2.21.3</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic/1.5.26 -->
+        <!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic/1.5.32 -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.26</version>
+            <version>1.5.32</version>
         </dependency>
 
-         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api/6.0.2 -->
+         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api/6.0.3 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
    


### PR DESCRIPTION
This pull request updates the `pom.xml` configuration for the project, focusing on dependency upgrades, developer information, and a version bump. The main goal is to keep dependencies current.

Dependency updates:

* Upgraded `jackson-databind` from version 2.21.0 to 2.21.3 for improved security and bug fixes.
* Upgraded `logback-classic` from version 1.5.26 to 1.5.32 for logging improvements and bug fixes.
* Upgraded `junit-jupiter-api` from version 6.0.2 to 6.0.3 for testing enhancements.

Project metadata updates:

* Updated developer contact information and timezones to use current emails and the `Europe/Stockholm` timezone; removed developer IDs and roles for a cleaner configuration.
* Bumped the project version from 1.2.2 to 1.2.3 to reflect these updates.